### PR TITLE
Add language-langium repo

### DIFF
--- a/otterdog/eclipse-langium.jsonnet
+++ b/otterdog/eclipse-langium.jsonnet
@@ -65,6 +65,9 @@ orgs.newOrg('ecd.langium', 'eclipse-langium') {
     },
     orgs.newRepo('langium-ai') {
     },
+    orgs.newRepo('language-langium') {
+      description: "Syntaxes for Langium.",
+    },
     orgs.newRepo('langium-previews') {
       default_branch: "previews",
       description: "Hosting PR previews for langium-website",


### PR DESCRIPTION
Adds a new repo to host just the langium grammar definitions (textmate, monarch, etc.). Motivating factor is adding Langium to the [linguist](https://github.com/github-linguist/linguist) project so it's a recognized language on Github.

Generally their approach makes a project a git submodule, and sources a grammar def from that. But the Langium project has additional textmate grammars & a slightly different grammar location, making it difficult to integrate as is. The intent is to source those grammar definitions from this repo separately to make that easier.

Additionally, the name is somewhat arbitrary, could also be `grammar-langium` or `langium-language` as well. If there are any preferences from those involved let me know.