### PR TITLE
Add Description + Topics to langium-ai

### DIFF
--- a/otterdog/eclipse-langium.jsonnet
+++ b/otterdog/eclipse-langium.jsonnet
@@ -64,6 +64,12 @@ orgs.newOrg('ecd.langium', 'eclipse-langium') {
       ],
     },
     orgs.newRepo('langium-ai') {
+      description: "A suite of tools for integrating AI applications with Langium DSLs",
+      topics+: [
+        "ai",
+        "language-engineering",
+        "typescript"
+      ],
     },
     orgs.newRepo('language-langium') {
       description: "Syntaxes for Langium.",


### PR DESCRIPTION
Just adds missing description & topics for the langium-ai reop, mostly for the description since that's been empty for a bit.