### PR TITLE
Add gated npm publish environment to Langium AI

### DIFF
--- a/otterdog/eclipse-langium.jsonnet
+++ b/otterdog/eclipse-langium.jsonnet
@@ -81,6 +81,18 @@ orgs.newOrg('ecd.langium', 'eclipse-langium') {
         "llm",
         "typescript",
       ],
+      environments: [
+        orgs.newEnvironment('npm-publish') {
+          reviewers+: [
+            "@montymxb",
+            "@dhuebner"
+          ],
+          branch_policies+: [
+            "main"
+          ],
+          deployment_branch_policy: "selected",
+        }
+      ]
     },
     orgs.newRepo('language-langium') {
       description: "Syntaxes for Langium.",


### PR DESCRIPTION
Adds a new environment to gate publishing to the current maintainers of Langium AI (myself & dhuebner). Once this is in we'll update the publishing workflow accordingly to leverage this environment.